### PR TITLE
Pin actions to a full-length commit SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - uses: ./
         with:
           lcov_path: 'test/lcov*.info'

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: reviewdog/action-setup@v1
+    - uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
       with:
         reviewdog_version: latest
     - shell: bash
@@ -79,7 +79,7 @@ runs:
       with:
         crate: lcov-util
         version: "0.2.1"
-    - uses: aki77/delete-pr-comments-action@v3
+    - uses: aki77/delete-pr-comments-action@ef208cb51cacbff428349ac715a337b2a07d62ef # v3.0.0
       if: inputs.delete_previous_comments == 'true'
       with:
         bodyContains: "[${{ inputs.tool_name }}]"


### PR DESCRIPTION
to support [Enforce SHA pinning](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/#enforce-sha-pinning)